### PR TITLE
Update _cpyrit_opencl.c

### DIFF
--- a/modules/cpyrit_opencl/_cpyrit_opencl.c
+++ b/modules/cpyrit_opencl/_cpyrit_opencl.c
@@ -40,7 +40,7 @@
 #include <Python.h>
 #include <structmember.h>
 #ifdef __APPLE__
-    #include <cl.h>
+    #include <OpenCL/cl.h>
 #else
     #include <CL/cl.h>
 #endif /* __APPLE__ */


### PR DESCRIPTION
Fix MacOS OpenCL include from <cl.h> to <OpenCL/cl.h>